### PR TITLE
Fix bug in __init_memmap for Windows OS

### DIFF
--- a/pyboof/__init__.py
+++ b/pyboof/__init__.py
@@ -157,7 +157,7 @@ def __init_memmap(size_mb=20):
     # Open file in read,write,binary mode
     pbg.mmap_fid = open(mmap_path, "r+b")
     if os.name == 'nt':
-        mmap_file = mmap.mmap(pbg.mmap_fid.fileno(), length=0)
+        pbg.mmap_file = mmap.mmap(pbg.mmap_fid.fileno(), length=0)
     else:
         pbg.mmap_file = mmap.mmap(pbg.mmap_fid.fileno(), length=0, flags=mmap.MAP_SHARED,
                               prot=mmap.PROT_READ | mmap.PROT_WRITE)


### PR DESCRIPTION
While using PyBoof, I encountered the following error when trying to load an image and perform QR code detection on it: 

```
...
File "C:\Users\taxig\anaconda3\envs\tavolo-env1\lib\site-packages\pyboof\common.py", line 179, in mmap_array_java_to_python
    mm.seek(0)
AttributeError: 'NoneType' object has no attribute 'seek'
```

The code I used to produce the bug is shown at the end of this post.

After digging, I found that the `mmap_file` global object is not intialized correctly for the Windows NT branch of code in the `def __init_memmap` function in `__init__.py`. It should be `pbg.mmap_file` instead of just `mmap_file`. (Note that the non-Windows NT code uses `pbg.mmap_file`.

When I changed `mmap_file` to `pbg.mmap_file`, the bug went away.

_Code to reproduce bug:_
```
# Testing pyboof library

import pyboof as pb
import numpy as np
import os

# Get path to image file
cwd = os.getcwd()
pic_fn = 'test_pic.png'
pic_path = os.path.join(cwd,pic_fn)

# Load image file with pyboof
img = pb.load_single_band(pic_path, np.uint8)

# Initialize QR code detector
detector = pb.FactoryFiducial(np.uint8).qrcode()

# Detect QR codes
detector.detect(img)
print('Detected a total of %d QR Codes' % (len(detector.detections)))
for qr in detector.detections:
    print("Message: " + qr.message)
    print("     at: " + str(qr.bounds))
```